### PR TITLE
Null out crec DistribTimestamp in case of Two-Phase tx

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2101,6 +2101,9 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	xlrec.crec.nsubxacts = nchildren;
 	xlrec.crec.nmsgs = ninvalmsgs;
 
+	xlrec.crec.distribTimeStamp = 0;
+	xlrec.crec.distribXid = 0;
+
 	rdata[0].data = (char *) (&xlrec);
 	rdata[0].len = MinSizeOfXactCommitPrepared;
 	rdata[0].buffer = InvalidBuffer;


### PR DESCRIPTION
Before:

```
rmgr: Transaction len (rec/tot):     72/   104, tx:          0, lsn: 0/0C041800, prev 0/0C041668, bkp: 0000, desc: commit prepared 735: 2024-09-23 12:25:58.645819 UTC gid = 268435455-0000000000 gid = 1727094134-0000000006 gxid = 6
```
gid = 268435455-0000000000  is some random trash from RecordTransactionCommitPrepared function stack.


After:

```
rmgr: Transaction len (rec/tot):     72/   104, tx:          0, lsn: 0/0C0425A8, prev 0/0C042410, bkp: 0000, desc: commit prepared 738: 2024-09-23 12:29:54.607165 UTC gid = 1727094550-0000000004 gxid = 4
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
