### PR TITLE
Rows out в EXPLAIN ANALYZE

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -283,7 +283,7 @@ int			gp_motion_slice_noop = 0;
 
 /* Greenplum Database Experimental Feature GUCs */
 int			gp_distinct_grouping_sets_threshold = 32;
-bool		gp_enable_explain_print_rows_out = FALSE;
+bool		gp_enable_explain_rows_out = FALSE;
 bool		gp_enable_explain_allstat = FALSE;
 bool		gp_enable_motion_deadlock_sanity = FALSE;	/* planning time sanity
 														 * check */

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -283,6 +283,7 @@ int			gp_motion_slice_noop = 0;
 
 /* Greenplum Database Experimental Feature GUCs */
 int			gp_distinct_grouping_sets_threshold = 32;
+bool		gp_enable_explain_print_rows_out = FALSE;
 bool		gp_enable_explain_allstat = FALSE;
 bool		gp_enable_motion_deadlock_sanity = FALSE;	/* planning time sanity
 														 * check */

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1855,7 +1855,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	 * Print "Rows out"
 	 */
 
-	if (gp_enable_explain_rows_out && es->analyze && ns->ninst > 1) {
+	if (gp_enable_explain_rows_out && es->analyze && ns->ninst > 0) {
 		double alltuples = 0;
 		double maxtuples = ns->insts[0].ntuples;
 		int maxseg = 0;
@@ -1901,8 +1901,8 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 		}
 		else {
 			// ExplainOpenGroup("Rows Out", NULL, false, es);
+			ExplainPropertyInteger("Workers", ns->ninst, es);
 			ExplainPropertyFloat("Average Rows", avgtuples, 1, es);
-			ExplainPropertyInteger("Segments", ns->ninst, es);
 			ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
 			ExplainPropertyInteger("Max Rows Segment", maxseg, es);
 			ExplainPropertyFloat("Min Rows", mintuples, 0, es);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1891,7 +1891,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 			appendStringInfoString(es->str, "Rows out: ");
 
 			appendStringInfo(es->str,
-								 "Avg %0.2f x %d workers. Max %0.f rows (seg%d). Min %0.f rows (seg%d)\n",
+								 "%0.2f rows avg x %d workers, %0.f rows max (seg%d), %0.f rows min (seg%d).\n",
 								 avgtuples,
 								 ns->ninst,
 								 maxtuples,
@@ -1902,7 +1902,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 		else {
 			// ExplainOpenGroup("Rows Out", NULL, false, es);
 			ExplainPropertyFloat("Average Rows", avgtuples, 1, es);
-			ExplainPropertyInteger("Workers", ns->ninst, es);
+			ExplainPropertyInteger("Segments", ns->ninst, es);
 			ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
 			ExplainPropertyInteger("Max Rows Segment", maxseg, es);
 			ExplainPropertyFloat("Min Rows", mintuples, 0, es);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1855,7 +1855,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	 * Print "Rows out"
 	 */
 
-	if (es->analyze && ns->ninst > 1) {
+	if (gp_enable_explain_print_rows_out && es->analyze && ns->ninst > 1) {
 		double alltuples = 0;
 		double maxtuples = ns->insts[0].ntuples;
 		int maxseg = 0;

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1902,7 +1902,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 		else {
 			// ExplainOpenGroup("Rows Out", NULL, false, es);
 			ExplainPropertyFloat("Average Rows", avgtuples, 1, es);
-			ExplainPropertyInteger("Segments", ns->ninst, es);
+			ExplainPropertyInteger("Workers", ns->ninst, es);
 			ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
 			ExplainPropertyInteger("Max Rows Segment", maxseg, es);
 			ExplainPropertyFloat("Min Rows", maxtuples, 0, es);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1855,7 +1855,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	 * Print "Rows out"
 	 */
 
-	if (gp_enable_explain_print_rows_out && es->analyze && ns->ninst > 1) {
+	if (gp_enable_explain_rows_out && es->analyze && ns->ninst > 1) {
 		double alltuples = 0;
 		double maxtuples = ns->insts[0].ntuples;
 		int maxseg = 0;

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1905,8 +1905,8 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 			ExplainPropertyInteger("Workers", ns->ninst, es);
 			ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
 			ExplainPropertyInteger("Max Rows Segment", maxseg, es);
-			ExplainPropertyFloat("Min Rows", maxtuples, 0, es);
-			ExplainPropertyInteger("Min Rows Segment", maxseg, es);
+			ExplainPropertyFloat("Min Rows", mintuples, 0, es);
+			ExplainPropertyInteger("Min Rows Segment", minseg, es);
 			// ExplainCloseGroup("Rows out", NULL, false, es);
 		}
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -870,6 +870,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
+		{"gp_enable_explain_print_rows_out", PGC_USERSET, CLIENT_CONN_OTHER,
+			gettext_noop("Experimental feature: print avg, min and max rows out in segments in EXPLAIN ANALYZE."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_explain_print_rows_out,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_enable_explain_allstat", PGC_USERSET, CLIENT_CONN_OTHER,
 			gettext_noop("Experimental feature: dump stats for all segments in EXPLAIN ANALYZE."),
 			NULL,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -870,12 +870,12 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_enable_explain_print_rows_out", PGC_USERSET, CLIENT_CONN_OTHER,
+		{"gp_enable_explain_rows_out", PGC_USERSET, CLIENT_CONN_OTHER,
 			gettext_noop("Experimental feature: print avg, min and max rows out in segments in EXPLAIN ANALYZE."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
-		&gp_enable_explain_print_rows_out,
+		&gp_enable_explain_rows_out,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -741,6 +741,13 @@ extern bool gp_enable_preunique;
  */
 extern bool gp_eager_preunique;
 
+/* May Greenplum print statistics as average, minimum and maximum rows out
+ * during EXPLAIN ANALYZE?
+ *
+ */
+
+extern bool gp_enable_explain_print_rows_out;
+
 /* May Greenplum dump statistics for all segments as a huge ugly string
  * during EXPLAIN ANALYZE?
  *

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -746,7 +746,7 @@ extern bool gp_eager_preunique;
  *
  */
 
-extern bool gp_enable_explain_print_rows_out;
+extern bool gp_enable_explain_rows_out;
 
 /* May Greenplum dump statistics for all segments as a huge ugly string
  * during EXPLAIN ANALYZE?

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -172,6 +172,7 @@
 		"gp_enable_agg_distinct_pruning",
 		"gp_enable_direct_dispatch",
 		"gp_enable_exchange_default_partition",
+		"gp_enable_explain_print_rows_out",
 		"gp_enable_explain_allstat",
 		"gp_enable_fast_sri",
 		"gp_enable_global_deadlock_detector",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -172,7 +172,7 @@
 		"gp_enable_agg_distinct_pruning",
 		"gp_enable_direct_dispatch",
 		"gp_enable_exchange_default_partition",
-		"gp_enable_explain_print_rows_out",
+		"gp_enable_explain_rows_out",
 		"gp_enable_explain_allstat",
 		"gp_enable_fast_sri",
 		"gp_enable_global_deadlock_detector",

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -340,7 +340,7 @@ explain analyze SELECT * FROM explaintest;
 -------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.266..0.384 rows=5 loops=2)
    ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.011..0.013 rows=2 loops=2)
-         Rows out: Avg 3.33 x 3 workers. Max 5 rows (seg1). Min 2 rows (seg2).
+         Rows out: 3.33 rows avg x 3 workers, 5 rows max (seg1), 2 rows min (seg2).
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -333,6 +333,22 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+-- Test explain rows out.
+set gp_enable_explain_rows_out=on;
+explain analyze SELECT * FROM explaintest;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.266..0.384 rows=5 loops=2)
+   ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.011..0.013 rows=2 loops=2)
+         Rows out: Avg 3.33 x 3 workers. Max 5 rows (seg1). Min 2 rows (seg2).
+   (slice0)    Executor memory: 322K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Total runtime: 2.600 ms
+(8 rows)
+
+set gp_enable_explain_rows_out=DEFAULT;
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -371,7 +371,7 @@ explain analyze SELECT * FROM explaintest;
 -------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.298..0.302 rows=5 loops=2)
    ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.013..0.015 rows=2 loops=2)
-         Rows out: Avg 3.33 x 3 workers. Max 5 rows (seg1). Min 2 rows (seg2).
+         Rows out: 3.33 rows avg x 3 workers, 5 rows max (seg1), 2 rows min (seg2).
    (slice0)    Executor memory: 290K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -364,6 +364,22 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+-- Test explain rows out.
+set gp_enable_explain_rows_out=on;
+explain analyze SELECT * FROM explaintest;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.298..0.302 rows=5 loops=2)
+   ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.013..0.015 rows=2 loops=2)
+         Rows out: Avg 3.33 x 3 workers. Max 5 rows (seg1). Min 2 rows (seg2).
+   (slice0)    Executor memory: 290K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
+ Total runtime: 1.577 ms
+(8 rows)
+
+set gp_enable_explain_rows_out=DEFAULT;
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -156,6 +156,11 @@ set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_allstat=DEFAULT;
 
+-- Test explain rows out.
+set gp_enable_explain_rows_out=on;
+explain analyze SELECT * FROM explaintest;
+set gp_enable_explain_rows_out=DEFAULT;
+
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --


### PR DESCRIPTION
Waiting until tests will be fixed in main

```
set gp_enable_explain_rows_out=on;

drop table if exists tt; create table tt (a int, b int) distributed randomly;

explain (analyze,verbose) insert into tt select * from generate_series(1,1000)a,generate_series(1,1000)b;

 Insert  (cost=0.00..495560.34 rows=333334 width=8) (actual time=3.829..1148.458 rows=333741 loops=1)
   Output: generate_series_1.generate_series, generate_series.generate_series, "outer".ColRef_0002, generate_series_1.generate_series
   Executor Memory: 1kB  Segments: 3  Max: 1kB (segment 0)
   Rows out: 333333.33 rows avg x 3 workers, 333741 rows max (seg1), 333054 rows min (seg2).
   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..479935.34 rows=333334 width=12) (actual time=3.707..761.241 rows=333741 loops=1)
         Output: generate_series_1.generate_series, generate_series.generate_series, "outer".ColRef_0002
         Rows out: 333333.33 rows avg x 3 workers, 333741 rows max (seg1), 333054 rows min (seg2).
         ->  Result  (cost=0.00..479922.82 rows=333334 width=12) (actual time=0.226..882.580 rows=1000000 loops=1)
               Output: generate_series_1.generate_series, generate_series.generate_series, 1
               Rows out: 333333.33 rows avg x 3 workers, 1000000 rows max (seg1), 0 rows min (seg0).
               ->  Result  (cost=0.00..479918.82 rows=333334 width=8) (actual time=0.225..631.202 rows=1000000 loops=1)
                     Output: generate_series_1.generate_series, generate_series.generate_series
                     One-Time Filter: (gp_execution_segment() = 1)
                     Rows out: 333333.33 rows avg x 3 workers, 1000000 rows max (seg1), 0 rows min (seg0).
                     ->  Nested Loop  (cost=0.00..479898.05 rows=333334 width=8) (actual time=0.220..386.554 rows=1000000 loops=1)
                           Output: generate_series_1.generate_series, generate_series.generate_series
                           Join Filter: true
                           Rows out: 333333.33 rows avg x 3 workers, 1000000 rows max (seg1), 0 rows min (seg0).
                           ->  Function Scan on pg_catalog.generate_series generate_series_1  (cost=0.00..0.00 rows=334 width=4) (actual time=0.102..0.333 rows=1000 loops=1)
                                 Output: generate_series_1.generate_series
                                 Function Call: generate_series(1, 1000)
                                 work_mem: 40kB  Segments: 1  Max: 40kB (segment 1)
                                 Rows out: 333.33 rows avg x 3 workers, 1000 rows max (seg1), 0 rows min (seg0).
                           ->  Function Scan on pg_catalog.generate_series  (cost=0.00..0.00 rows=334 width=4) (actual time=0.000..0.092 rows=999 loops=1001)
                                 Output: generate_series.generate_series
                                 Function Call: generate_series(1, 1000)
                                 work_mem: 40kB  Segments: 1  Max: 40kB (segment 1)
                                 Rows out: 333333.67 rows avg x 3 workers, 1000001 rows max (seg1), 0 rows min (seg0).
 Planning time: 5.981 ms
   (slice0)    Executor memory: 87K bytes avg x 3 workers, 87K bytes max (seg0).
   (slice1)    Executor memory: 97K bytes avg x 3 workers, 172K bytes max (seg1).  Work_mem: 40K bytes max.
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 1180.349 ms
(34 rows)
```



```
explain (analyze,verbose,format text) select * from tt where a > b;

                                                          QUERY PLAN                                                           
-------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=2.534..223.679 rows=499500 loops=1)
   Output: a, b
   ->  Seq Scan on public.tt  (cost=0.00..431.00 rows=1 width=8) (actual time=0.145..127.350 rows=166742 loops=1)
         Output: a, b
         Filter: (tt.a > tt.b)
         Rows out: 166500.00 rows avg x 3 workers, 166742 rows max (seg0), 166340 rows min (seg2).
 Planning time: 2.578 ms
   (slice0)    Executor memory: 183K bytes.
   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 245.018 ms
(12 rows)
```




## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
